### PR TITLE
Less use of reflection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.swinglabs.swingx:swingx-graphics:1.6.5-1'
-    implementation 'org.swinglabs.swingx:swingx-core:1.6.5-1'
     implementation 'org.swinglabs.swingx:swingx-mavensupport:1.6.5-1'
     compileOnly 'org.kohsuke.metainf-services:metainf-services:1.8'
     annotationProcessor 'org.kohsuke.metainf-services:metainf-services:1.8'

--- a/src/main/java/org/jdesktop/swingx/BackgroundPaintable.java
+++ b/src/main/java/org/jdesktop/swingx/BackgroundPaintable.java
@@ -28,7 +28,7 @@ import org.jdesktop.swingx.painter.Painter;
  * @author kschaefer
  */
 @SuppressWarnings("rawtypes")
-interface BackgroundPaintable {
+public interface BackgroundPaintable {
     /**
      * Returns the current background painter.
      * 

--- a/src/main/java/org/jdesktop/swingx/SwingXUtilities.java
+++ b/src/main/java/org/jdesktop/swingx/SwingXUtilities.java
@@ -35,7 +35,6 @@ import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -81,12 +80,7 @@ public final class SwingXUtilities {
      * A helper for creating and updating key bindings for components with
      * mnemonics. The {@code pressed} action will be invoked when the mnemonic
      * is activated.
-     * <p>
-     * TODO establish an interface for the mnemonic properties, such as {@code
-     * MnemonicEnabled} and change signature to {@code public static <T extends
-     * JComponent & MnemonicEnabled> void updateMnemonicBinding(T c, String
-     * pressed)}
-     * 
+     *
      * @param c
      *            the component bindings to update
      * @param pressed
@@ -95,7 +89,7 @@ public final class SwingXUtilities {
      * @throws NullPointerException
      *             if the component is {@code null}
      */
-    public static void updateMnemonicBinding(JComponent c, String pressed) {
+    public static <T extends JComponent & Mnemonicable> void updateMnemonicBinding(T c, String pressed) {
         updateMnemonicBinding(c, pressed, null);
     }
     
@@ -104,12 +98,7 @@ public final class SwingXUtilities {
      * mnemonics. The {@code pressed} action will be invoked when the mnemonic
      * is activated and the {@code released} action will be invoked when the
      * mnemonic is deactivated.
-     * <p>
-     * TODO establish an interface for the mnemonic properties, such as {@code
-     * MnemonicEnabled} and change signature to {@code public static <T extends
-     * JComponent & MnemonicEnabled> void updateMnemonicBinding(T c, String
-     * pressed, String released)}
-     * 
+     *
      * @param c
      *            the component bindings to update
      * @param pressed
@@ -122,19 +111,9 @@ public final class SwingXUtilities {
      * @throws NullPointerException
      *             if the component is {@code null}
      */
-    public static void updateMnemonicBinding(JComponent c, String pressed, String released) {
-        Class<?> clazz = c.getClass();
-        int m = -1;
-        
-        try {
-            Method mtd = clazz.getMethod("getMnemonic");
-            m = (Integer) mtd.invoke(c);
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("unable to access mnemonic", e);
-        }
-        
+    public static <T extends JComponent & Mnemonicable> void updateMnemonicBinding(T c, String pressed, String released) {
+        int m = c.getMnemonic();
+
         InputMap map = SwingUtilities.getUIInputMap(c,
                 JComponent.WHEN_IN_FOCUSED_WINDOW);
         

--- a/src/main/java/org/jdesktop/swingx/plaf/LookAndFeelAddons.java
+++ b/src/main/java/org/jdesktop/swingx/plaf/LookAndFeelAddons.java
@@ -39,6 +39,7 @@ import javax.swing.UIManager;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.UIResource;
 
+import org.jdesktop.swingx.BackgroundPaintable;
 import org.jdesktop.swingx.painter.Painter;
 
 /**
@@ -506,22 +507,11 @@ public abstract class LookAndFeelAddons {
      *             if the component does not contain the "backgroundPainter" property or the
      *             property cannot be set
      */
-    public static void installBackgroundPainter(JComponent c, String painter) {
-        Class<?> clazz = c.getClass();
+    public static <T extends JComponent & BackgroundPaintable> void installBackgroundPainter(T c, String painter) {
+        Painter<?> p = c.getBackgroundPainter();
 
-        try {
-            Method getter = clazz.getMethod("getBackgroundPainter");
-            Method setter = clazz.getMethod("setBackgroundPainter", Painter.class);
-
-            Painter<?> p = (Painter<?>) getter.invoke(c);
-
-            if (p == null || p instanceof UIResource) {
-                setter.invoke(c, UIManagerExt.getPainter(painter));
-            }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("cannot set painter on " + c.getClass());
+        if (p == null || p instanceof UIResource) {
+            c.setBackgroundPainter(UIManagerExt.getPainter(painter));
         }
     }
 
@@ -537,22 +527,11 @@ public abstract class LookAndFeelAddons {
      *             if the component does not contain the "backgroundPainter" property or the
      *             property cannot be set
      */
-    public static void uninstallBackgroundPainter(JComponent c) {
-        Class<?> clazz = c.getClass();
+    public static <T extends JComponent & BackgroundPaintable> void uninstallBackgroundPainter(T c) {
+        Painter<?> p = c.getBackgroundPainter();
 
-        try {
-            Method getter = clazz.getMethod("getBackgroundPainter");
-            Method setter = clazz.getMethod("setBackgroundPainter", Painter.class);
-
-            Painter<?> p = (Painter<?>) getter.invoke(c);
-
-            if (p == null || p instanceof UIResource) {
-                setter.invoke(c, (Painter<?>) null);
-            }
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("cannot set painter on " + c.getClass());
+        if (p == null || p instanceof UIResource) {
+            c.setBackgroundPainter(null);
         }
     }
 }

--- a/src/main/java/org/jdesktop/swingx/plaf/basic/BasicHyperlinkUI.java
+++ b/src/main/java/org/jdesktop/swingx/plaf/basic/BasicHyperlinkUI.java
@@ -33,7 +33,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.Reader;
 import java.io.StringReader;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.logging.Logger;
 
@@ -540,39 +539,41 @@ public class BasicHyperlinkUI extends BasicButtonUI {
          * was created for.
          */
         static class BasicDocument extends HTMLDocument {
-        private static Class<?> clz;
-        private static Method displayPropertiesToCSS;
-
-        /** The host, that is where we are rendering. */
-        // private JComponent host;
-        // --------- 1.5 x 1.6 incompatibility handling ....
-        static {
-            String j5 = "com.sun.java.swing.SwingUtilities2";
-            String j6 = "sun.swing.SwingUtilities2";
-            try {
-                // assume 1.6
-                clz = Class.forName(j6);
-            } catch (ClassNotFoundException e) {
-                // or maybe not ..
-                try {
-                    clz = Class.forName(j5);
-                } catch (ClassNotFoundException e1) {
-                    throw new RuntimeException("Failed to find SwingUtilities2. Check the classpath.");
-                }
-            }
-            try {
-                displayPropertiesToCSS = clz.getMethod("displayPropertiesToCSS", new Class[] { Font.class, Color.class});
-            } catch (Exception e) {
-                throw new RuntimeException("Failed to use SwingUtilities2. Check the permissions and class version.");
-            }
-        }
 
         private static String displayPropertiesToCSS(Font f, Color c) {
-            try {
-                return (String) displayPropertiesToCSS.invoke(null, new Object[] { f, c });
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            StringBuilder rule = new StringBuilder("body {");
+            if (f != null) {
+                rule.append(" font-family: ");
+                rule.append(f.getFamily());
+                rule.append(" ; ");
+                rule.append(" font-size: ");
+                rule.append(f.getSize());
+                rule.append("pt ;");
+                if (f.isBold()) {
+                    rule.append(" font-weight: 700 ; ");
+                }
+                if (f.isItalic()) {
+                    rule.append(" font-style: italic ; ");
+                }
             }
+            if (c != null) {
+                rule.append(" color: #");
+                if (c.getRed() < 16) {
+                    rule.append('0');
+                }
+                rule.append(Integer.toHexString(c.getRed()));
+                if (c.getGreen() < 16) {
+                    rule.append('0');
+                }
+                rule.append(Integer.toHexString(c.getGreen()));
+                if (c.getBlue() < 16) {
+                    rule.append('0');
+                }
+                rule.append(Integer.toHexString(c.getBlue()));
+                rule.append(" ; ");
+            }
+            rule.append(" }");
+            return rule.toString();
         }
 
         // --------- EO 1.5 x 1.6 incompatibility handling ....


### PR DESCRIPTION
The BasicHyperlinkUI class uses reflection on sun.* internal classes which generates warning on Java 11 and error on Java 17. This patch reduces the use of reflection and eliminates this possible warnings/errors.